### PR TITLE
fix: Sales Invoice doesn't have substitute_payment_entry attribute

### DIFF
--- a/erpnext_mexico_compliance/controllers/common.py
+++ b/erpnext_mexico_compliance/controllers/common.py
@@ -238,17 +238,14 @@ class CommonController(Document):
         cfdi = CFDI.from_string(self.mx_stamped_xml.encode("utf-8"))
         ws = get_ws_client()
 
-        substitute = (
-            frappe.get_doc("Payment Entry", self.substitute_payment_entry)
-            if self.substitute_payment_entry
-            else None
-        )
+        substitute_name = getattr(self, substitute_field)
+        substitute_uuid = None
+        if substitute_name:
+            substitute = frappe.get_doc(self.doctype, self.substitute_payment_entry)
+            substitute_uuid = substitute.cfdi_uuid
 
         self.cancellation_acknowledgement = ws.cancel(
-            certificate,
-            cfdi,
-            self.cancellation_reason,
-            substitute.cfdi_uuid if substitute else None,
+            certificate, cfdi, self.cancellation_reason, substitute_uuid
         )
 
         ret = self.save()

--- a/erpnext_mexico_compliance/public/js/payment_entry.js
+++ b/erpnext_mexico_compliance/public/js/payment_entry.js
@@ -106,12 +106,14 @@ function cancel(frm) {
       },
     ],
     async ({ certificate }) => {
-      const { message: cfdi_msg } = await frm.call("cancel_cfdi", {
-        certificate,
+      const { message: cfdi_msg } = await frappe.call({
+        method: "cancel_cfdi",
+        doc: frm.doc,
+        args: { certificate },
+        btn: $(".btn-secondary"),
+        freeze: true,
       });
       frappe.show_alert({ message: cfdi_msg, indicator: "green" });
-      const { message: cancelled } = await frm.call("cancel");
-      frappe.show_alert({ message: cancelled, indicator: "green" });
       frm.reload_doc();
     },
     __("Select a Certificate to sign the CFDI")

--- a/erpnext_mexico_compliance/public/js/sales_invoice.js
+++ b/erpnext_mexico_compliance/public/js/sales_invoice.js
@@ -103,7 +103,13 @@ function cancel(frm) {
         },
       ],
       async ({ certificate }) => {
-        await frm.call("cancel_cfdi", { certificate });
+        await frappe.call({
+          method: "cancel_cfdi",
+          doc: frm.doc,
+          args: { certificate },
+          btn: $(".btn-secondary"),
+          freeze: true,
+        });
         frm.reload_doc();
       },
       __("Select a Certificate to sign the CFDI")


### PR DESCRIPTION
- **fix: streamline cancellation process by simplifying substitute handling**
- **fix: enhance cancellation process by disabling cancel button and freeze document**
